### PR TITLE
Add SwiftUI ARKit app for camera distance measurement

### DIFF
--- a/apps/CameraDistanceApp/ARCameraDistanceView.swift
+++ b/apps/CameraDistanceApp/ARCameraDistanceView.swift
@@ -1,0 +1,101 @@
+import SwiftUI
+import ARKit
+
+struct ARCameraDistanceView: UIViewRepresentable {
+    @Binding var distanceInMeters: Double?
+    @Binding var isLocked: Bool
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(distance: $distanceInMeters, isLocked: $isLocked)
+    }
+
+    func makeUIView(context: Context) -> ARSCNView {
+        let view = ARSCNView(frame: .zero)
+        view.delegate = context.coordinator
+        view.session.delegate = context.coordinator
+        view.automaticallyUpdatesLighting = true
+        view.debugOptions = []
+        view.scene = SCNScene()
+
+        let configuration = ARWorldTrackingConfiguration()
+        configuration.planeDetection = [.horizontal, .vertical]
+        configuration.environmentTexturing = .automatic
+        if ARWorldTrackingConfiguration.supportsSceneReconstruction(.mesh) {
+            configuration.sceneReconstruction = .mesh
+        }
+        view.session.run(configuration)
+        return view
+    }
+
+    func updateUIView(_ uiView: ARSCNView, context: Context) {
+        context.coordinator.isLocked = isLocked
+    }
+
+    final class Coordinator: NSObject, ARSCNViewDelegate, ARSessionDelegate {
+        @Binding var distance: Double?
+        @Binding var isLocked: Bool
+        private var lastUpdateTime: TimeInterval = 0
+        private let throttlingInterval: TimeInterval = 0.05
+
+        init(distance: Binding<Double?>, isLocked: Binding<Bool>) {
+            self._distance = distance
+            self._isLocked = isLocked
+        }
+
+        func renderer(_ renderer: SCNSceneRenderer, updateAtTime time: TimeInterval) {
+            guard !isLocked else { return }
+            guard time - lastUpdateTime >= throttlingInterval else { return }
+            lastUpdateTime = time
+
+            guard let sceneView = renderer as? ARSCNView,
+                  let frame = sceneView.session.currentFrame else {
+                return
+            }
+
+            let center = CGPoint(x: sceneView.bounds.midX, y: sceneView.bounds.midY)
+            let hitTestTypes: ARHitTestResult.ResultType = [.existingPlaneUsingGeometry, .existingPlaneUsingExtent, .featurePoint]
+            let results = sceneView.hitTest(center, types: hitTestTypes)
+
+            guard let result = results.first else {
+                DispatchQueue.main.async {
+                    self.distance = nil
+                }
+                return
+            }
+
+            let cameraTransform = frame.camera.transform
+            let cameraPosition = SIMD3<Float>(cameraTransform.columns.3.x,
+                                              cameraTransform.columns.3.y,
+                                              cameraTransform.columns.3.z)
+            let targetTransform = result.worldTransform
+            let targetPosition = SIMD3<Float>(targetTransform.columns.3.x,
+                                              targetTransform.columns.3.y,
+                                              targetTransform.columns.3.z)
+
+            let distanceMeters = simd_distance(cameraPosition, targetPosition)
+
+            DispatchQueue.main.async {
+                self.distance = Double(distanceMeters)
+            }
+        }
+
+        func session(_ session: ARSession, didFailWithError error: Error) {
+            NSLog("ARSession failed: \(error.localizedDescription)")
+        }
+
+        func sessionWasInterrupted(_ session: ARSession) {
+            NSLog("ARSession interrupted")
+        }
+
+        func sessionInterruptionEnded(_ session: ARSession) {
+            NSLog("ARSession interruption ended, resetting tracking")
+            let configuration = ARWorldTrackingConfiguration()
+            configuration.planeDetection = [.horizontal, .vertical]
+            configuration.environmentTexturing = .automatic
+            if ARWorldTrackingConfiguration.supportsSceneReconstruction(.mesh) {
+                configuration.sceneReconstruction = .mesh
+            }
+            session.run(configuration, options: [.resetTracking, .removeExistingAnchors])
+        }
+    }
+}

--- a/apps/CameraDistanceApp/CameraDistanceApp.swift
+++ b/apps/CameraDistanceApp/CameraDistanceApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct CameraDistanceApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/apps/CameraDistanceApp/ContentView.swift
+++ b/apps/CameraDistanceApp/ContentView.swift
@@ -1,0 +1,135 @@
+import SwiftUI
+import ARKit
+
+struct ContentView: View {
+    @State private var distanceInMeters: Double?
+    @State private var isLocked: Bool = false
+    @State private var selectedUnit: DistanceUnit = .meters
+
+    private static let distanceFormatter: MeasurementFormatter = {
+        let formatter = MeasurementFormatter()
+        formatter.unitStyle = .medium
+        formatter.unitOptions = .providedUnit
+        return formatter
+    }()
+
+    private var formattedDistance: String {
+        guard let distanceInMeters else {
+            return "Align the reticle with your target"
+        }
+        let measurement = Measurement(value: distanceInMeters, unit: UnitLength.meters)
+            .converted(to: selectedUnit.unit)
+        return Self.distanceFormatter.string(from: measurement)
+    }
+
+    var body: some View {
+        ZStack {
+            ARCameraDistanceView(distanceInMeters: $distanceInMeters, isLocked: $isLocked)
+                .edgesIgnoringSafeArea(.all)
+
+            VStack {
+                Text("Center the reticle on the object to measure how far it is from your device.")
+                    .font(.footnote)
+                    .padding(.top, 16)
+                    .padding(.horizontal, 20)
+                    .multilineTextAlignment(.center)
+                    .background(Color.black.opacity(0.35).blur(radius: 0))
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .padding(.top, 24)
+
+                Spacer()
+
+                VStack(spacing: 12) {
+                    Text(formattedDistance)
+                        .font(.system(size: 28, weight: .semibold, design: .rounded))
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 10)
+                        .background(Color.black.opacity(0.55))
+                        .clipShape(Capsule())
+
+                    Picker("Units", selection: $selectedUnit) {
+                        ForEach(DistanceUnit.allCases) { unit in
+                            Text(unit.displayName).tag(unit)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .padding(.horizontal)
+
+                    Button(action: { isLocked.toggle() }) {
+                        Label(isLocked ? "Unlock Live Reading" : "Lock This Distance", systemImage: isLocked ? "lock.open" : "lock")
+                            .frame(maxWidth: .infinity)
+                            .padding()
+                            .background(Color.blue.opacity(0.85))
+                            .foregroundStyle(.white)
+                            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                    }
+                }
+                .padding(24)
+                .background(Color.black.opacity(0.35))
+                .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+                .padding()
+            }
+
+            ReticleView()
+                .frame(width: 120, height: 120)
+        }
+        .preferredColorScheme(.dark)
+    }
+}
+
+private struct ReticleView: View {
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(Color.white.opacity(0.65), lineWidth: 2)
+            Circle()
+                .stroke(Color.white.opacity(0.3), lineWidth: 1)
+                .scaleEffect(0.55)
+            Rectangle()
+                .fill(Color.white.opacity(0.65))
+                .frame(width: 2, height: 20)
+            Rectangle()
+                .fill(Color.white.opacity(0.65))
+                .frame(width: 20, height: 2)
+        }
+    }
+}
+
+enum DistanceUnit: String, CaseIterable, Identifiable {
+    case meters
+    case centimeters
+    case feet
+    case inches
+
+    var id: String { rawValue }
+
+    var unit: UnitLength {
+        switch self {
+        case .meters:
+            return .meters
+        case .centimeters:
+            return .centimeters
+        case .feet:
+            return .feet
+        case .inches:
+            return .inches
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .meters:
+            return "Meters"
+        case .centimeters:
+            return "Centimeters"
+        case .feet:
+            return "Feet"
+        case .inches:
+            return "Inches"
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/apps/CameraDistanceApp/Info.plist
+++ b/apps/CameraDistanceApp/Info.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDisplayName</key>
+    <string>Camera Distance</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.example.cameradistance</string>
+    <key>NSCameraUsageDescription</key>
+    <string>The camera is required to analyze depth information and measure how far objects are from your device.</string>
+    <key>UIApplicationSceneManifest</key>
+    <dict>
+        <key>UIApplicationSupportsMultipleScenes</key>
+        <true/>
+    </dict>
+</dict>
+</plist>

--- a/apps/CameraDistanceApp/README.md
+++ b/apps/CameraDistanceApp/README.md
@@ -1,0 +1,29 @@
+# Camera Distance App
+
+This SwiftUI + ARKit sample lets you measure the distance between the iPhone/iPad camera and the object that sits under the on-screen reticle. The app continuously performs raycasts from the camera through the center of the screen and reports the closest feature or plane that it intersects. A lock button lets you freeze the current measurement so that you can reposition the device without losing the captured value.
+
+## Requirements
+
+- Xcode 15 or newer
+- iOS 16 or newer device that supports LiDAR or at least ARKit world tracking
+- Enable camera access when prompted
+
+## Running the project
+
+1. Create an empty SwiftUI App project in Xcode named `CameraDistanceApp` (or drag these source files into a new project).
+2. Replace the template-generated SwiftUI files with `CameraDistanceApp.swift`, `ContentView.swift`, and `ARCameraDistanceView.swift` from this folder.
+3. Update the app's `Info.plist` with the provided keys, especially the `NSCameraUsageDescription`.
+4. Build and run on a physical device. The simulator does not provide camera or ARKit capabilities.
+
+## How it works
+
+- The `ARCameraDistanceView` hosts an `ARSCNView` configured with world tracking, plane detection, and (where available) scene reconstruction.
+- Every few frames, the renderer performs a hit test from the center of the screen against detected planes and feature points. This gives you the 3D position of the object under the reticle.
+- The camera pose comes from the current AR frame. We compute the Euclidean distance between the camera and the hit-test result to determine how far the object is from the device.
+- A segmented control lets you view the result in meters, centimeters, feet, or inches. The lock button stops the AR session from updating the binding so that you can keep the measurement.
+
+You can enhance this sample by:
+
+- Drawing a virtual line between the camera origin and the measured point using SceneKit overlays.
+- Capturing multiple measurements and storing them in a list.
+- Leveraging LiDAR depth data for even more stable hits when the hardware supports it.


### PR DESCRIPTION
## Summary
- add a SwiftUI + ARKit sample app that uses a central reticle to read the distance from the camera to the targeted point
- expose locking and unit selection controls together with a reusable `UIViewRepresentable` wrapper around `ARSCNView`
- document build requirements and Info.plist camera permission entry needed to run on device

## Testing
- not run (iOS-only project)


------
https://chatgpt.com/codex/tasks/task_e_68d16d6495ec8321a30ec9199a4360e0