### PR TITLE
Add browser-based camera distance measurement app

### DIFF
--- a/distance-app/README.md
+++ b/distance-app/README.md
@@ -1,0 +1,36 @@
+# Camera Distance Measure
+
+This is a lightweight web app that uses the phone (or desktop) camera to estimate the distance from the camera to an object of known height. It works entirely in the browser using the MediaDevices API, so no native installation is required.
+
+## How it works
+
+1. Start the camera (ideally the rear camera on a phone) and grant permission when prompted.
+2. Capture a frame to freeze the current view.
+3. Tap or click the bottom of the object and then its top.
+4. Enter the real-world height of the object and the camera's vertical field-of-view (FOV). The FOV defaults to 60°, which is a good starting point for many smartphone cameras. You can calibrate this value using an object at a known distance.
+5. The app calculates the distance using a simple pinhole camera model:
+
+   \[
+   \text{distance} = \frac{\text{actual height} \times \text{image height}}{\text{pixel height} \times 2 \tan(\text{FOV} / 2)}
+   \]
+
+The output is displayed in metres and centimetres.
+
+## Running locally
+
+You can open `index.html` directly in a modern mobile browser, but serving it over `https://` (or `http://localhost`) is required for camera access. The simplest option is to run a static file server inside this folder:
+
+```bash
+cd distance-app
+python -m http.server 8000
+```
+
+Then browse to [http://localhost:8000](http://localhost:8000) from your desktop or mobile device. If you are testing on a phone, ensure that the device is on the same network and replace `localhost` with your machine's IP address.
+
+## Notes and limitations
+
+- Estimation accuracy depends heavily on the correctness of the FOV value and how precisely you tap the object's top and bottom.
+- Tall objects produce more reliable readings because they occupy more pixels in the frame.
+- To improve accuracy, calibrate the FOV by measuring a known distance and adjusting the FOV input until the displayed result matches reality.
+- Browsers require a secure context (HTTPS or localhost) for camera access. Opening the file directly from disk may prevent the camera from working.
+- The app stops camera tracks when the page is closed, but you can also revoke access from the browser's privacy settings if needed.

--- a/distance-app/app.js
+++ b/distance-app/app.js
@@ -1,0 +1,241 @@
+const video = document.getElementById('video');
+const overlay = document.getElementById('overlay');
+const ctx = overlay.getContext('2d');
+const startBtn = document.getElementById('start');
+const captureBtn = document.getElementById('capture');
+const resetBtn = document.getElementById('reset');
+const statusEl = document.getElementById('status');
+const actualHeightInput = document.getElementById('actual-height');
+const fovInput = document.getElementById('fov');
+const distanceOutput = document.getElementById('distance');
+
+let stream = null;
+let capturedFrame = null;
+let points = [];
+
+const toRadians = (deg) => (deg * Math.PI) / 180;
+
+function setStatus(message = '', type = 'info') {
+  statusEl.textContent = message;
+  statusEl.classList.remove('ok', 'error');
+  if (type === 'ok') {
+    statusEl.classList.add('ok');
+  } else if (type === 'error') {
+    statusEl.classList.add('error');
+  }
+}
+
+function syncCanvasSize() {
+  if (!video.videoWidth || !video.videoHeight) {
+    return;
+  }
+  overlay.width = video.videoWidth;
+  overlay.height = video.videoHeight;
+}
+
+function clearMeasurement() {
+  points = [];
+  if (capturedFrame) {
+    renderOverlay();
+  } else {
+    ctx.clearRect(0, 0, overlay.width, overlay.height);
+  }
+  updateMeasurement();
+}
+
+function renderOverlay() {
+  if (!capturedFrame) {
+    ctx.clearRect(0, 0, overlay.width, overlay.height);
+    return;
+  }
+
+  ctx.clearRect(0, 0, overlay.width, overlay.height);
+  ctx.drawImage(capturedFrame, 0, 0, overlay.width, overlay.height);
+
+  const radius = Math.max(overlay.width, overlay.height) / 120;
+  ctx.lineWidth = Math.max(overlay.width, overlay.height) / 360;
+  ctx.strokeStyle = '#38bdf8';
+  ctx.fillStyle = '#22d3ee';
+
+  points.forEach((point, index) => {
+    ctx.beginPath();
+    ctx.arc(point.x, point.y, radius, 0, Math.PI * 2);
+    ctx.fill();
+
+    ctx.fillStyle = '#0f172a';
+    ctx.font = `${radius * 1.2}px/1 'Inter', sans-serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(index === 0 ? '1' : '2', point.x, point.y);
+    ctx.fillStyle = '#22d3ee';
+  });
+
+  if (points.length === 2) {
+    ctx.beginPath();
+    ctx.moveTo(points[0].x, points[0].y);
+    ctx.lineTo(points[1].x, points[1].y);
+    ctx.stroke();
+  }
+}
+
+function updateMeasurement() {
+  if (!capturedFrame || points.length !== 2) {
+    distanceOutput.textContent = '–';
+    return;
+  }
+
+  const actualHeight = Number.parseFloat(actualHeightInput.value);
+  const fov = Number.parseFloat(fovInput.value);
+
+  if (!(actualHeight > 0)) {
+    setStatus('Enter the actual height of the object in centimetres.', 'error');
+    distanceOutput.textContent = '–';
+    return;
+  }
+
+  if (!(fov > 0)) {
+    setStatus('Enter a valid field-of-view between 10° and 120°.', 'error');
+    distanceOutput.textContent = '–';
+    return;
+  }
+
+  const imageHeight = overlay.height;
+  const pixelDistance = Math.abs(points[0].y - points[1].y);
+
+  if (pixelDistance < 5) {
+    setStatus('The selected points are too close together to estimate the distance.', 'error');
+    distanceOutput.textContent = '–';
+    return;
+  }
+
+  const angle = toRadians(fov);
+  const denominator = pixelDistance * 2 * Math.tan(angle / 2);
+
+  if (denominator <= 0) {
+    setStatus('Unable to compute the distance with the current parameters.', 'error');
+    distanceOutput.textContent = '–';
+    return;
+  }
+
+  const distanceCm = (actualHeight * imageHeight) / denominator;
+
+  if (!Number.isFinite(distanceCm) || distanceCm <= 0) {
+    setStatus('The calculation produced an invalid distance. Adjust your inputs and try again.', 'error');
+    distanceOutput.textContent = '–';
+    return;
+  }
+
+  const distanceMeters = distanceCm / 100;
+  distanceOutput.textContent = `${distanceMeters.toFixed(2)} m (${distanceCm.toFixed(0)} cm)`;
+  setStatus('Distance estimate updated. Calibrate the FOV for higher accuracy.', 'ok');
+}
+
+async function startCamera() {
+  if (!navigator.mediaDevices?.getUserMedia) {
+    setStatus('Camera access is not supported in this browser.', 'error');
+    return;
+  }
+
+  try {
+    stream = await navigator.mediaDevices.getUserMedia({
+      video: {
+        facingMode: { ideal: 'environment' },
+        width: { ideal: 1080 },
+        height: { ideal: 1920 },
+      },
+      audio: false,
+    });
+
+    video.srcObject = stream;
+    await video.play();
+    syncCanvasSize();
+    capturedFrame = null;
+    overlay.classList.remove('interactive');
+    clearMeasurement();
+    startBtn.disabled = true;
+    captureBtn.disabled = false;
+    resetBtn.disabled = true;
+    setStatus('Camera ready. Capture a frame to start measuring.', 'ok');
+  } catch (error) {
+    console.error(error);
+    setStatus(`Could not access the camera: ${error.message}`, 'error');
+  }
+}
+
+function stopCamera() {
+  if (!stream) {
+    return;
+  }
+  stream.getTracks().forEach((track) => track.stop());
+  stream = null;
+}
+
+async function captureFrame() {
+  if (!stream || !video.videoWidth) {
+    setStatus('Start the camera and wait for it to initialise before capturing.', 'error');
+    return;
+  }
+
+  syncCanvasSize();
+  capturedFrame = document.createElement('canvas');
+  capturedFrame.width = overlay.width;
+  capturedFrame.height = overlay.height;
+  const snapshotContext = capturedFrame.getContext('2d');
+  snapshotContext.drawImage(video, 0, 0, overlay.width, overlay.height);
+
+  overlay.classList.add('interactive');
+  clearMeasurement();
+  renderOverlay();
+  resetBtn.disabled = false;
+  setStatus('Frame captured. Tap the bottom (1) then the top (2) of the object.', 'info');
+}
+
+function handlePointer(event) {
+  if (!capturedFrame) {
+    return;
+  }
+
+  event.preventDefault();
+  const rect = overlay.getBoundingClientRect();
+  const scaleX = overlay.width / rect.width;
+  const scaleY = overlay.height / rect.height;
+  const x = (event.clientX - rect.left) * scaleX;
+  const y = (event.clientY - rect.top) * scaleY;
+
+  if (points.length >= 2) {
+    points = [];
+  }
+  points.push({ x, y });
+
+  if (points.length === 1) {
+    setStatus('Now tap the top of the object.', 'info');
+  } else if (points.length === 2) {
+    setStatus('Distance estimate updated. Adjust FOV if needed.', 'ok');
+  }
+
+  renderOverlay();
+  updateMeasurement();
+}
+
+function resetPoints() {
+  if (!capturedFrame) {
+    return;
+  }
+  points = [];
+  renderOverlay();
+  updateMeasurement();
+  setStatus('Points cleared. Tap the frame to pick them again.', 'info');
+}
+
+startBtn.addEventListener('click', startCamera);
+captureBtn.addEventListener('click', captureFrame);
+resetBtn.addEventListener('click', resetPoints);
+overlay.addEventListener('pointerdown', handlePointer);
+actualHeightInput.addEventListener('input', updateMeasurement);
+fovInput.addEventListener('input', updateMeasurement);
+
+video.addEventListener('loadedmetadata', syncCanvasSize);
+
+window.addEventListener('beforeunload', stopCamera);
+
+setStatus('Allow camera access, capture a frame, then mark the object to measure the distance.');

--- a/distance-app/index.html
+++ b/distance-app/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Camera Distance Measure</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <main class="app">
+    <header class="header">
+      <h1>Camera Distance Measure</h1>
+      <p>Use your phone camera to estimate the distance to an object by marking its top and bottom in the captured frame.</p>
+    </header>
+
+    <section class="controls">
+      <div class="control-group">
+        <label for="actual-height">Actual object height (cm)</label>
+        <input id="actual-height" type="number" min="1" value="170" />
+      </div>
+      <div class="control-group">
+        <label for="fov">Camera vertical FOV (degrees)</label>
+        <input id="fov" type="number" min="10" max="120" value="60" />
+        <small>Default is 60°. You can calibrate this value using a known distance.</small>
+      </div>
+      <div class="buttons">
+        <button id="start">Start camera</button>
+        <button id="capture" disabled>Capture frame</button>
+        <button id="reset" disabled>Reset points</button>
+      </div>
+      <p id="status" class="status" role="status" aria-live="polite"></p>
+    </section>
+
+    <section class="viewer">
+      <div class="video-wrapper">
+        <video id="video" autoplay playsinline></video>
+        <canvas id="overlay"></canvas>
+      </div>
+      <p class="hint">Tap or click on the captured frame to mark the bottom and top of the object.</p>
+    </section>
+
+    <section class="result">
+      <h2>Estimated Distance</h2>
+      <output id="distance">–</output>
+      <p class="explanation">Distance is computed from the relative height of the object in the frame and the vertical field of view.</p>
+    </section>
+
+    <section class="troubleshooting">
+      <h2>Tips</h2>
+      <ul>
+        <li>Stand still after capturing the frame to avoid motion blur.</li>
+        <li>Measure an object whose actual height you know precisely.</li>
+        <li>Calibrate the FOV by measuring a known distance and adjusting the value until it matches.</li>
+      </ul>
+    </section>
+  </main>
+  <script type="module" src="app.js"></script>
+</body>
+</html>

--- a/distance-app/styles.css
+++ b/distance-app/styles.css
@@ -1,0 +1,209 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  font-size: 16px;
+  background-color: #0d1117;
+  color: #f0f6fc;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  padding: 1.5rem;
+  box-sizing: border-box;
+}
+
+.app {
+  width: min(900px, 100%);
+  background: rgba(13, 17, 23, 0.8);
+  border: 1px solid rgba(240, 246, 252, 0.1);
+  border-radius: 18px;
+  padding: 1.5rem;
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(12px);
+}
+
+.header h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(1.5rem, 4vw, 2.4rem);
+}
+
+.header p {
+  margin: 0;
+  color: #8b949e;
+}
+
+.controls {
+  display: grid;
+  gap: 1rem;
+  margin: 1.5rem 0;
+}
+
+.control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+label {
+  font-weight: 600;
+}
+
+input[type='number'] {
+  background: rgba(240, 246, 252, 0.05);
+  border: 1px solid rgba(240, 246, 252, 0.1);
+  border-radius: 10px;
+  color: inherit;
+  padding: 0.6rem 0.8rem;
+  font-size: 1rem;
+}
+
+input[type='number']:focus {
+  outline: 2px solid rgba(56, 189, 248, 0.5);
+  outline-offset: 2px;
+}
+
+small {
+  color: #8b949e;
+}
+
+.buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.status {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #8b949e;
+  min-height: 1.2rem;
+  transition: color 0.2s ease;
+}
+
+.status.ok {
+  color: #34d399;
+}
+
+.status.error {
+  color: #f87171;
+}
+
+button {
+  background: linear-gradient(135deg, #3b82f6, #06b6d4);
+  border: none;
+  color: white;
+  padding: 0.7rem 1.2rem;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, filter 0.2s ease;
+}
+
+button:disabled {
+  background: rgba(240, 246, 252, 0.1);
+  cursor: not-allowed;
+  color: #8b949e;
+}
+
+button:not(:disabled):active {
+  transform: scale(0.97);
+}
+
+.viewer {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.video-wrapper {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 9 / 16;
+  background: #010409;
+  border-radius: 18px;
+  overflow: hidden;
+  border: 1px solid rgba(240, 246, 252, 0.1);
+}
+
+video,
+canvas {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+canvas {
+  pointer-events: none;
+}
+
+canvas.interactive {
+  pointer-events: auto;
+  cursor: crosshair;
+}
+
+.viewer .hint {
+  color: #8b949e;
+  margin: 0;
+}
+
+.result {
+  margin-top: 1.5rem;
+  padding: 1rem;
+  background: rgba(240, 246, 252, 0.05);
+  border-radius: 12px;
+  border: 1px solid rgba(240, 246, 252, 0.08);
+}
+
+.result h2 {
+  margin: 0 0 0.5rem;
+}
+
+#distance {
+  display: block;
+  font-size: 2.4rem;
+  font-weight: 700;
+}
+
+.explanation {
+  margin: 0.5rem 0 0;
+  color: #8b949e;
+}
+
+.troubleshooting {
+  margin-top: 2rem;
+}
+
+.troubleshooting h2 {
+  margin: 0 0 0.5rem;
+}
+
+.troubleshooting ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: #8b949e;
+}
+
+@media (max-width: 600px) {
+  body {
+    padding: 1rem;
+  }
+
+  .app {
+    padding: 1.2rem;
+  }
+
+  .buttons {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  button {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- add a standalone web app that uses the device camera and a pinhole model to estimate distance to an object of known height
- implement interactive capture and measurement workflow with touch-friendly UI and contextual guidance
- document how to serve the static files locally and how the distance calculation works

## Testing
- not run (static web app)


------
https://chatgpt.com/codex/tasks/task_e_68d16d6495ec8321a30ec9199a4360e0